### PR TITLE
Feature/BPT5-52 card carousel slide [서치인풋 반응형 수정, 카드리스트내부의 상품이미지 슬라이드, 링크샵프로덕트 이미지 wapper로 감싸기]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
         "react-dom": "^19.1.0",
         "react-modal": "^3.16.3",
         "react-router-dom": "^7.6.1",
+        "react-slick": "^0.30.3",
         "react-toastify": "^11.0.5",
+        "slick-carousel": "^1.8.1",
         "styled-components": "^6.1.18"
       },
       "devDependencies": {
@@ -1889,6 +1891,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2151,6 +2159,12 @@
       "integrity": "sha512-hwtetwfKNZo/UlwHIVBlKZVdy7o8bIZxxKs0Mv/ROPiQQQmDgdm5a+KvKtBsxM8ZjFzTaCeLoodZ8jiBE3o9rA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/enquire.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
+      "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==",
+      "license": "MIT"
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -3641,6 +3655,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3693,6 +3714,15 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json2mq": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-convert": "^0.2.0"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -3762,6 +3792,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4340,6 +4376,23 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-slick": {
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.30.3.tgz",
+      "integrity": "sha512-B4x0L9GhkEWUMApeHxr/Ezp2NncpGc+5174R02j+zFiWuYboaq98vmxwlpafZfMjZic1bjdIqqmwLDcQY0QaFA==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "enquire.js": "^2.1.6",
+        "json2mq": "^0.2.0",
+        "lodash.debounce": "^4.0.8",
+        "resize-observer-polyfill": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-toastify": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
@@ -4396,6 +4449,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -4699,6 +4758,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/slick-carousel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jquery": ">=1.8.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4721,6 +4789,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/string-convert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
+      "license": "MIT"
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "react-dom": "^19.1.0",
     "react-modal": "^3.16.3",
     "react-router-dom": "^7.6.1",
+    "react-slick": "^0.30.3",
     "react-toastify": "^11.0.5",
+    "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.18"
   },
   "devDependencies": {

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -28,6 +28,9 @@ const CardWrapper = styled.div`
     width: calc((100% - 24px) / 2);
     max-width: 589px;
   }
+  &:hover {
+    box-shadow: 0px 0px 5px 3px #eee;
+  }
 `;
 const ProductImgWrapper = styled.div`
   width: 100%;
@@ -40,6 +43,10 @@ const CustomSliderWrapper = styled(Slider)`
     top: 50%;
     transform: translateY(-50%);
     font-size: 0;
+  }
+  .slick-next.slick-disabled {
+    background-color: red;
+
   }
   /* 이전 버튼 */
   .slick-prev {
@@ -102,9 +109,17 @@ function Card({
     cssEase: 'linear',
     autoplay: false, // 초기 자동 재생은 false로 설정합니다.
     autoplaySpeed: 1000,
-    pauseOnHover: true, // 직접 제어하므로 false로 설정합니다.
+    centerPadding: '12px',
+    pauseOnHover: true,
     //반응형 설정 (예시)
     responsive: [
+      {
+        breakpoint: 480, // 화면 너비가 768px 이하일 때
+        settings: {
+          slidesToShow: 3,
+          infinite: false,
+        },
+      },
       {
         breakpoint: 768, // 화면 너비가 768px 이하일 때
         settings: {
@@ -113,10 +128,9 @@ function Card({
         },
       },
       {
-        breakpoint: 480, // 화면 너비가 480px 이하일 때
+        breakpoint: 1024, // 화면 너비가 480px 이하일 때
         settings: {
-          slidesToShow: 3,
-          centerPadding: '12px',
+          slidesToShow: 5,
           infinite: false,
         },
       },

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,7 +1,13 @@
+import { useRef, useEffect, useState } from 'react';
+
+import Slider from 'react-slick';
 import styled from 'styled-components';
+
+import 'slick-carousel/slick/slick.css';
 
 import LinkshopProductImage from './LinkshopProductImage';
 import LinkshopProfileInfo from './LinkshopProfileInfo';
+import btn_back from '../assets/icon/btn_back.png';
 import { applyFontStyles } from '../styles/mixins';
 import { FontTypes } from '../styles/theme';
 
@@ -12,25 +18,62 @@ const CardWrapper = styled.div`
   background-color: ${({ theme }) => theme.colors.secWhite100};
   border-radius: 25px;
   padding: 24px;
+  width: 100%;
+  min-width: 344px;
+  @media (min-width: 768px) {
+    width: calc(100% - 8px);
+    min-width: 342px;
+  }
   @media (min-width: 1024px) {
-    width: 587px;
+    width: calc((100% - 24px) / 2);
+    max-width: 589px;
   }
 `;
 const ProductImgWrapper = styled.div`
-  display: flex;
-  gap: 12px;
-  flex-wrap: nowrap;
-  overflow-x: scroll;
-  /* WebKit 기반 브라우저 (Chrome, Safari, Edge) 스크롤바 숨기기 */
-  &::-webkit-scrollbar {
-    display: none; /* 스크롤바 트랙 자체를 숨김 */
-    width: 0; /* 폭을 0으로 설정하여 공간 차지하지 않게 함 */
-    height: 0; /* 높이를 0으로 설정하여 공간 차지하지 않게 함 */
-  }
+  width: 100%;
+`;
 
-  /* Firefox 스크롤바 숨기기 (또는 얇게 만들기) */
-  scrollbar-width: thin;
-  -ms-overflow-style: none; /* IE 및 Edge (레거시) 스크롤바 숨기기 */
+const CustomSliderWrapper = styled(Slider)`
+  padding-right: 30px;
+  .slick-prev, .slick-next {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 0;
+  }
+  /* 이전 버튼 */
+  .slick-prev {
+    display: none important;
+  }
+  /* 다음 버튼 */
+  .slick-next {
+    right: -5px;
+    background-color: #eee;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+
+    &:before {
+      content: '';
+      display:block;
+      background-image:url(${btn_back});
+      width: 20px;
+      height: 20px;
+      background-repeat: no-repeat;
+      background-position: -3px center;
+      transform: rotate(180deg);
+    }
+  }
+  .slick-track {
+    margin-left: inherit;
+  }
+   @media (min-width: 1024px) {
+    padding-right: 0;
+    .slick-next {
+      display:none !important;
+    }
+  }
+}
 `;
 const TotalProducts = styled.div`
   ${({ $fontType = FontTypes.REGULAR16 }) => applyFontStyles($fontType)};
@@ -45,8 +88,73 @@ function Card({
   productsCount,
   productImageSrcs,
 }) {
+  const sliderRef = useRef(null);
+  const [isLargeScreen, setIsLargeScreen] = useState(false);
+
+  const sliderSettings = {
+    dots: false, // 하단에 점(dot) 내비게이션 표시
+    infinite: false, // 마지막 슬라이드에서 멈춤 (false: 루프 안 함, true: 루프 함)
+    speed: 500, // 슬라이드 전환 속도
+    slidesToShow: 5, // 한 번에 보여줄 슬라이드 개수
+    slidesToScroll: 1, // 한 번 스크롤/슬라이드 시 넘어갈 슬라이드 개수
+    arrows: true, // 좌우 화살표 내비게이션 표시
+    draggable: true,
+    cssEase: 'linear',
+    autoplay: false, // 초기 자동 재생은 false로 설정합니다.
+    autoplaySpeed: 1000,
+    pauseOnHover: true, // 직접 제어하므로 false로 설정합니다.
+    //반응형 설정 (예시)
+    responsive: [
+      {
+        breakpoint: 768, // 화면 너비가 768px 이하일 때
+        settings: {
+          slidesToShow: 4,
+          infinite: false,
+        },
+      },
+      {
+        breakpoint: 480, // 화면 너비가 480px 이하일 때
+        settings: {
+          slidesToShow: 3,
+          centerPadding: '12px',
+          infinite: false,
+        },
+      },
+    ],
+  };
+
+  const handleAutoPlay = () => {
+    if (sliderRef.current) {
+      sliderRef.current.slickPlay(); // slickPlay() 메서드 호출
+    }
+  };
+
+  // 마우스 이탈 시 자동 재생 정지
+  const handleRemoveAutoPlay = () => {
+    if (sliderRef.current) {
+      sliderRef.current.slickPause(); // slickPause() 메서드 호출
+    }
+  };
+  useEffect(() => {
+    const checkScreenSizeAndResetSlider = () => {
+      setIsLargeScreen(window.innerWidth >= 768);
+      // 슬라이더가 마운트되어 있으면 첫 번째 요소로 돌아가기
+      if (sliderRef.current) {
+        sliderRef.current.slickGoTo(0, true); // 0번째 슬라이드로 이동, true는 즉시 전환
+      }
+    };
+    checkScreenSizeAndResetSlider();
+    window.addEventListener('resize', checkScreenSizeAndResetSlider);
+  }, []); // ⭐️ 의존성 배열은 빈 배열: 컴포넌트 마운트 시 한 번만 실행되도록 합니다.
+
   return (
-    <CardWrapper>
+    <CardWrapper
+      {...(isLargeScreen && {
+        // 1024이상 사이즈 에서만 호버시 오토플레이 & 벗어낫을지 오토플레이 해제 이벤트 적용
+        onMouseEnter: handleAutoPlay,
+        onMouseLeave: handleRemoveAutoPlay,
+      })}
+    >
       <LinkshopProfileInfo
         onClick={handleClick}
         userId={userId}
@@ -56,10 +164,23 @@ function Card({
         isLiked={isLiked}
       />
       <TotalProducts>대표상품 {productsCount}</TotalProducts>
-      <ProductImgWrapper>
-        {productImageSrcs.map((src, index) => (
-          <LinkshopProductImage key={index} src={src} name={name} />
-        ))}
+      <ProductImgWrapper
+        {...(isLargeScreen && {
+          // 슬라이드로 돌아가는 상품이미지에 마우스가 hover됐을 시 오토플레이 멈추고 벗어나면 재실행
+          onMouseMove: handleRemoveAutoPlay,
+          onMouseLeave: handleAutoPlay,
+        })}
+      >
+        <CustomSliderWrapper ref={sliderRef} {...sliderSettings}>
+          {productImageSrcs.map((src, index) => (
+            // 각 LinkshopProductImage는 Slider의 자식으로 들어갑니다.
+            // Slider는 각 자식을 감싸는 div를 자동으로 생성합니다.
+            <div key={index}>
+              {/* Slider의 자식은 반드시 div로 감싸져야 합니다. */}
+              <LinkshopProductImage src={src} name={name} />
+            </div>
+          ))}
+        </CustomSliderWrapper>
       </ProductImgWrapper>
     </CardWrapper>
   );

--- a/src/components/CardList.jsx
+++ b/src/components/CardList.jsx
@@ -13,6 +13,7 @@ const CardListWrapper = styled.div`
     width: 1199px;
     flex-direction: row;
     justify-content: flex-start;
+    gap: 24px;
   }
 `;
 

--- a/src/components/LinkshopProductImage.jsx
+++ b/src/components/LinkshopProductImage.jsx
@@ -4,11 +4,16 @@ import { useEffect, useState } from 'react'; // useState 훅 import
 import styled from 'styled-components';
 
 const DEFAULT_PRODUCT_IMG = 'https://placehold.co/95x95';
-
-const ProductImage = styled.img`
+const ProductImgWrapper = styled.div`
   width: 95px;
   height: 95px;
+  overflow: hidden;
   border-radius: 15px;
+`;
+const ProductImage = styled.img`
+  width: 100%;
+  height: 100%;
+
   object-fit: cover;
   object-position: center;
   aspect-ratio: 1/1;
@@ -29,11 +34,13 @@ function LinkshopProductImage({ src, alt }) {
   };
 
   return (
-    <ProductImage
-      src={currentSrc || DEFAULT_PRODUCT_IMG} // currentSrc가 없거나 null이면 기본 이미지 사용
-      alt={alt}
-      onError={handleImageError} // 이미지 로드 실패 시 handleImageError 함수 호출
-    />
+    <ProductImgWrapper>
+      <ProductImage
+        src={currentSrc || DEFAULT_PRODUCT_IMG} // currentSrc가 없거나 null이면 기본 이미지 사용
+        alt={alt}
+        onError={handleImageError} // 이미지 로드 실패 시 handleImageError 함수 호출
+      />
+    </ProductImgWrapper>
   );
 }
 

--- a/src/components/SearchInput.jsx
+++ b/src/components/SearchInput.jsx
@@ -4,7 +4,7 @@ import searchIcon from '../assets/icon/ic_search.png';
 
 const SearchInputContainer = styled.div`
   position: relative;
-  width: 344px;
+  min-width: 344px;
   height: 50px;
   border: 1px solid #dddcdf;
   border-radius: 49px;
@@ -15,12 +15,12 @@ const SearchInputContainer = styled.div`
 
   /* 태블릿 (768px 이상 1023px 이하) : 696px */
   @media (min-width: 768px) {
-    width: 696px;
+    min-width: 696px;
   }
 
   /* 데스크탑 (1024px 이상) : 1199px */
   @media (min-width: 1024px) {
-    width: 1199px;
+    min-width: 1199px;
   }
 `;
 


### PR DESCRIPTION
<img width="315" alt="image" src="https://github.com/user-attachments/assets/bc7a1407-e710-4326-8acb-81aaec5bd288" />

1. 우선 ... 태블릿, 모바일의 경우 next 버튼으로 상품을 한개씩 넘길수 있는데 여기서 더이상 슬라이드할게 없을시 저 버튼을 어떻게 처리할까요 ?display:none으로 없애버릴지 아니면 버튼색을 다르게 ..? 아 버튼 색상도 추천받겠습니다. (prev버튼도 살릴지 고민이됩니다...)

<img width="1502" alt="image" src="https://github.com/user-attachments/assets/d2850746-ef52-4abc-b642-3744ecfd9467" />

2. 카드내부의 상품이 5개 이하일경우 카드를 호버해도 자동슬라이드가 적용되지 않게 구현했습니다. 또 카드 상품에 직접 호버가 되는경우에도 자동슬라이드를 해제하였고 벗어났을시 다시 자동재생하게 구현했습니다.

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/c2ef5cdc-a34a-41a0-9684-99795bf2f09c" />

3. 문제는.... 이렇게 width:1024px에서 width:786px로 화면을 줄이거나 늘릴때 상품의 간격이 너무 넓다는것입니다.. 이건 링크샵 프로덕트 이미지사이즈를 vw로 잡아보면 어떨까 생각하고있는데 (현재는 95px로 고정되어있습니다)좋은 방법이 있다면 추천부탁드리겠습니다.

4. 추가적으로 상품이 무한루프되지않습니다. 즉 만약 5개의 슬라이드아이템이있다면 5개가 모두 보여지면 오토플레이가 멈추게됩니다. 모바일과 태블릿에서도 5개의상품이 모두 보여진다면 마지막 슬라이드에서 멈춰있게됩니다. 이부분은 
**slidesToShow: 5, // 한 번에 보여줄 슬라이드 개수를 설정**  (해당 라이브러리가 초기 셋팅기준을 데스크탑으로 잡고있습니다.)
이렇게 셋팅해놓았기 때문인거같은데 무한루프를 적용해보니 상품갯수가 5개 미만인경우에는 루프가 이상하게 돌더라구요 ..? 그래서 무한루프를 적용하지않았는데 이부분은 개선방법을 더 찾아보겠습니다..

마지막으로 바쁜 시기에 휴가를쓰게되어서.. 불편한마음이듭니다 복귀하면 열심히 참여하겠습니다ㅠㅠ

++ 서치컴포넌트 반응형 수정하였습니다 ! 

<img width="1447" alt="image" src="https://github.com/user-attachments/assets/d68fc965-61dc-4e50-856b-1af69a3e9a7b" />

++ 카드 hover시 box-shadow를 추가해보았습니다. (첫번째 카드가 hover되어있는 상태입니다.) 혹시 강조할수있는 다른효과가 있다면 추천 부탁드립니다 ! 
