### PR TITLE
Feature/BPT5-57:메인 페이지 개선

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -8,6 +8,7 @@ import 'slick-carousel/slick/slick.css';
 import LinkshopProductImage from './LinkshopProductImage';
 import LinkshopProfileInfo from './LinkshopProfileInfo';
 import btn_back from '../assets/icon/btn_back.png';
+import { useCardData } from '../hooks/useCardsData';
 import { applyFontStyles } from '../styles/mixins';
 import { FontTypes } from '../styles/theme';
 
@@ -87,19 +88,24 @@ const CustomSliderWrapper = styled(Slider)`
 const TotalProducts = styled.div`
   ${({ $fontType = FontTypes.REGULAR16 }) => applyFontStyles($fontType)};
 `;
-function Card({
-  id,
-  name,
-  userId,
-  imageUrl,
-  likes,
-  isLiked,
-  productsCount,
-  productImageSrcs,
-  onToggleLike: handleToggleLike,
-}) {
+function Card({ cardData }) {
   const [showAmount, setShowAmount] = useState(1);
   const [isLargeScreen, setIsLargeScreen] = useState(false);
+
+  const {
+    card: {
+      id,
+      userId,
+      name,
+      shop: { imageUrl },
+      likes,
+      isLiked,
+      productsCount,
+      productImageSrcs,
+    },
+    handleToggleLike,
+  } = useCardData(cardData);
+
   const sliderRef = useRef(null);
   const wrapperRef = useRef(null);
 

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -26,23 +26,12 @@ const CardWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 8px;
+  width: 100%;
   background-color: ${({ theme }) => theme.colors.secWhite100};
   border-radius: 25px;
   padding: 24px;
-
-  width: 100%;
-  min-width: 344px;
-  @media (min-width: 768px) {
-    width: calc(100% - 8px);
-    min-width: 342px;
-  }
-  @media (min-width: 1024px) {
-    width: calc((100% - 24px) / 2);
-    max-width: 589px;
-  }
   &:hover {
     animation: ${fadeInShadow} 0.6s forwards;
-    cursor: pointer;
   }
 `;
 

--- a/src/components/CardList.jsx
+++ b/src/components/CardList.jsx
@@ -24,7 +24,7 @@ const CardListWrapper = styled.div`
   }
 `;
 
-function CardList({ cardData: initialCardData, isLoading }) {
+function CardList({ cardData: initialCardData, $isLoading }) {
   const [cards, setCards] = useState(initialCardData); // 카드 리스트 상태 관리
 
   useEffect(() => {
@@ -65,7 +65,7 @@ function CardList({ cardData: initialCardData, isLoading }) {
     }
   }, []);
 
-  if (!isLoading && cards.length === 0) {
+  if (!$isLoading && cards.length === 0) {
     return <NoSearchResult />;
   }
 

--- a/src/components/CardList.jsx
+++ b/src/components/CardList.jsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 
 import Card from './Card';
 import NoSearchResult from './NoSearchResult';
-import { useCardsData } from '../hooks/useCardsData';
 
 const CardListWrapper = styled.div`
   width: 100%;
@@ -37,30 +36,16 @@ const StyledLink = styled(Link)`
   }
 `;
 
-function CardList({ cardData: initialCardData, $isLoading }) {
-  const { cards, handleToggleLike } = useCardsData(initialCardData);
-
-  if (!$isLoading && cards.length === 0) {
+function CardList({ cardData, $isLoading }) {
+  if (!$isLoading && cardData.length === 0) {
     return <NoSearchResult />;
   }
 
   return (
     <CardListWrapper>
-      {cards.map(cardItem => (
+      {cardData.map(cardItem => (
         <StyledLink key={cardItem.id} to={`/link/${cardItem.userId}`}>
-          <Card
-            id={cardItem.id}
-            name={cardItem.name}
-            userId={cardItem.userId}
-            imageUrl={cardItem.shop.imageUrl}
-            likes={cardItem.likes}
-            isLiked={cardItem.isLiked}
-            productsCount={cardItem.productsCount}
-            productImageSrcs={cardItem.products.map(
-              product => product.imageUrl,
-            )}
-            onToggleLike={handleToggleLike}
-          />
+          <Card cardData={cardItem} />
         </StyledLink>
       ))}
     </CardListWrapper>

--- a/src/components/CardList.jsx
+++ b/src/components/CardList.jsx
@@ -1,11 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
-
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import Card from './Card';
 import NoSearchResult from './NoSearchResult';
-import { createLike, deleteLike } from '../api/api';
+import { useCardsData } from '../hooks/useCardsData';
 
 const CardListWrapper = styled.div`
   width: 100%;
@@ -40,45 +38,7 @@ const StyledLink = styled(Link)`
 `;
 
 function CardList({ cardData: initialCardData, $isLoading }) {
-  const [cards, setCards] = useState(initialCardData); // 카드 리스트 상태 관리
-
-  useEffect(() => {
-    setCards(initialCardData);
-  }, [initialCardData]);
-
-  const handleToggleLike = useCallback(async (id, currentIsLiked) => {
-    // 1. UI를 즉시 업데이트 (낙관적 업데이트)
-    setCards(prevCards =>
-      prevCards.map(cardItem =>
-        cardItem.id === id
-          ? {
-              ...cardItem,
-              isLiked: !currentIsLiked,
-              likes: currentIsLiked ? cardItem.likes - 1 : cardItem.likes + 1,
-            }
-          : cardItem,
-      ),
-    );
-
-    try {
-      if (!currentIsLiked) await createLike(id);
-      else await deleteLike(id);
-    } catch (error) {
-      console.error('좋아요 API 호출 실패:', error);
-      // 2. API 호출 실패 시 UI를 이전 상태로 롤백
-      setCards(prevCards =>
-        prevCards.map(cardItem =>
-          cardItem.id === id
-            ? {
-                ...cardItem,
-                isLiked: currentIsLiked, // 원래 상태로 되돌림
-                likes: currentIsLiked ? cardItem.likes + 1 : cardItem.likes - 1, // 원래 개수로 되돌림
-              }
-            : cardItem,
-        ),
-      );
-    }
-  }, []);
+  const { cards, handleToggleLike } = useCardsData(initialCardData);
 
   if (!$isLoading && cards.length === 0) {
     return <NoSearchResult />;

--- a/src/components/CardList.jsx
+++ b/src/components/CardList.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import Card from './Card';
@@ -21,6 +22,20 @@ const CardListWrapper = styled.div`
     flex-direction: row;
     justify-content: flex-start;
     gap: 24px;
+  }
+`;
+
+const StyledLink = styled(Link)`
+  display: block;
+  width: 100%;
+  min-width: 344px;
+  @media (min-width: 768px) {
+    width: calc(100% - 8px);
+    min-width: 342px;
+  }
+  @media (min-width: 1024px) {
+    width: calc((100% - 24px) / 2);
+    max-width: 589px;
   }
 `;
 
@@ -72,18 +87,21 @@ function CardList({ cardData: initialCardData, $isLoading }) {
   return (
     <CardListWrapper>
       {cards.map(cardItem => (
-        <Card
-          key={cardItem.id}
-          id={cardItem.id}
-          name={cardItem.name}
-          userId={cardItem.userId}
-          imageUrl={cardItem.shop.imageUrl}
-          likes={cardItem.likes}
-          isLiked={cardItem.isLiked}
-          productsCount={cardItem.productsCount}
-          productImageSrcs={cardItem.products.map(product => product.imageUrl)}
-          onToggleLike={handleToggleLike}
-        />
+        <StyledLink key={cardItem.id} to={`/link/${cardItem.userId}`}>
+          <Card
+            id={cardItem.id}
+            name={cardItem.name}
+            userId={cardItem.userId}
+            imageUrl={cardItem.shop.imageUrl}
+            likes={cardItem.likes}
+            isLiked={cardItem.isLiked}
+            productsCount={cardItem.productsCount}
+            productImageSrcs={cardItem.products.map(
+              product => product.imageUrl,
+            )}
+            onToggleLike={handleToggleLike}
+          />
+        </StyledLink>
       ))}
     </CardListWrapper>
   );

--- a/src/components/Likes.jsx
+++ b/src/components/Likes.jsx
@@ -31,7 +31,8 @@ const Likes = ({
 }) => {
   const src = isLiked ? filledHeartImg : emptyHeartImg;
 
-  const handleToggleLikeClick = () => {
+  const handleToggleLikeClick = e => {
+    e.preventDefault();
     handleToggleLike(id, isLiked);
   };
 

--- a/src/components/LoadingIndicator.jsx
+++ b/src/components/LoadingIndicator.jsx
@@ -75,7 +75,7 @@ const LoadingIndicator = ({
     </IndicatorContainer>
   ) : (
     !$isEmptyList && (
-      <NoMoreDataContainer>모든 데이터를 불러왔습니다</NoMoreDataContainer>
+      <NoMoreDataContainer>{'모든 콘텐츠를 불러왔어요 :)'}</NoMoreDataContainer>
     )
   );
 };

--- a/src/components/LoadingIndicator.jsx
+++ b/src/components/LoadingIndicator.jsx
@@ -1,6 +1,7 @@
 import styled, { css, keyframes } from 'styled-components';
 
-import { ColorTypes } from '../styles/theme';
+import { applyFontStyles } from '../styles/mixins';
+import { ColorTypes, FontTypes } from '../styles/theme';
 
 const rotate = keyframes`
   from {
@@ -40,19 +41,35 @@ const IndicatorContainer = styled.div`
   justify-content: center;
   align-items: center;
 
+  ${({ $isLoading }) => {
+    return (
+      !$isLoading &&
+      css`
+        visibility: hidden;
+      `
+    );
+  }}
+
   ${({ $isInitialLoad }) => $isInitialLoad && centerIndicatorStyles}
-  padding: ${({ $isInitialLoad }) => ($isInitialLoad ? 0 : '32px 0 10vh')};
+  padding: ${({ $isInitialLoad }) => ($isInitialLoad ? 0 : '32px 0')};
 `;
 
-const LoadingIndicator = ({ isLoading, $isInitialLoad }) => {
-  if (!isLoading) {
-    return null;
-  }
+const NoMoreDataContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 114px;
 
-  return (
-    <IndicatorContainer $isInitialLoad={$isInitialLoad}>
+  ${applyFontStyles(FontTypes.REGULAR16, ColorTypes.SECONDARY_GRAY_200)}
+`;
+
+const LoadingIndicator = ({ $isLoading, $hasMore, $isInitialLoad }) => {
+  return $hasMore ? (
+    <IndicatorContainer $isLoading={$isLoading} $isInitialLoad={$isInitialLoad}>
       <Spinner />
     </IndicatorContainer>
+  ) : (
+    <NoMoreDataContainer>모든 데이터를 불러왔습니다</NoMoreDataContainer>
   );
 };
 

--- a/src/components/LoadingIndicator.jsx
+++ b/src/components/LoadingIndicator.jsx
@@ -63,13 +63,20 @@ const NoMoreDataContainer = styled.div`
   ${applyFontStyles(FontTypes.REGULAR16, ColorTypes.SECONDARY_GRAY_200)}
 `;
 
-const LoadingIndicator = ({ $isLoading, $hasMore, $isInitialLoad }) => {
+const LoadingIndicator = ({
+  $isLoading,
+  $hasMore,
+  $isEmptyList,
+  $isInitialLoad,
+}) => {
   return $hasMore ? (
     <IndicatorContainer $isLoading={$isLoading} $isInitialLoad={$isInitialLoad}>
       <Spinner />
     </IndicatorContainer>
   ) : (
-    <NoMoreDataContainer>모든 데이터를 불러왔습니다</NoMoreDataContainer>
+    !$isEmptyList && (
+      <NoMoreDataContainer>모든 데이터를 불러왔습니다</NoMoreDataContainer>
+    )
   );
 };
 

--- a/src/hooks/useAsync.js
+++ b/src/hooks/useAsync.js
@@ -1,0 +1,37 @@
+import { useState, useCallback } from 'react';
+
+export const useAsync = (
+  asyncFunction,
+  { delayLoadingTransition = false, delayLoadingTime = 500 },
+) => {
+  const [data, setData] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const execute = useCallback(
+    async (...args) => {
+      setIsLoading(true);
+      setError(null);
+      setData(null);
+      try {
+        const response = await asyncFunction(...args);
+        setData(response);
+        return response;
+      } catch (error) {
+        setError(error);
+        throw error;
+      } finally {
+        if (delayLoadingTransition) {
+          setTimeout(() => {
+            setIsLoading(false);
+          }, delayLoadingTime);
+        } else {
+          setIsLoading(false);
+        }
+      }
+    },
+    [asyncFunction, delayLoadingTransition, delayLoadingTime],
+  );
+
+  return { execute, data, isLoading, error };
+};

--- a/src/hooks/useCardsData.js
+++ b/src/hooks/useCardsData.js
@@ -3,53 +3,52 @@ import { useCallback, useEffect, useState } from 'react';
 import { useOptimisticUpdate } from './useOptimisticUpdate';
 import { createLike, deleteLike } from '../api/api';
 
-export const useCardsData = initialCardData => {
-  const [cards, setCards] = useState(initialCardData);
+export const useCardData = cardData => {
+  const [card, setCard] = useState(cardData);
+  const productImageSrcs = cardData.products.map(product => product.imageUrl);
 
   const { execute: addLike } = useOptimisticUpdate(
     createLike,
-    useCallback(id => {
-      setCards(prevCards =>
-        prevCards.map(cardItem =>
-          cardItem.id === id
-            ? { ...cardItem, isLiked: true, likes: cardItem.likes + 1 }
-            : cardItem,
-        ),
-      );
-    }, []),
-
-    useCallback(id => {
-      setCards(prevCards =>
-        prevCards.map(cardItem =>
-          cardItem.id === id
-            ? { ...cardItem, isLiked: false, likes: cardItem.likes - 1 }
-            : cardItem,
-        ),
-      );
-    }, []),
+    useCallback(
+      id =>
+        setCard(prevCard => ({
+          ...prevCard,
+          isLiked: true,
+          likes: prevCard.likes + 1,
+        })),
+      [],
+    ),
+    useCallback(
+      id =>
+        setCard(prevCard => ({
+          ...prevCard,
+          isLiked: false,
+          likes: prevCard.likes - 1,
+        })),
+      [],
+    ),
   );
 
   const { execute: removeLike } = useOptimisticUpdate(
     deleteLike,
-    useCallback(id => {
-      setCards(prevCards =>
-        prevCards.map(cardItem =>
-          cardItem.id === id
-            ? { ...cardItem, isLiked: false, likes: cardItem.likes - 1 }
-            : cardItem,
-        ),
-      );
-      console.log(cards);
-    }, []),
-    useCallback(id => {
-      setCards(prevCards =>
-        prevCards.map(cardItem =>
-          cardItem.id === id
-            ? { ...cardItem, isLiked: true, likes: cardItem.likes + 1 }
-            : cardItem,
-        ),
-      );
-    }, []),
+    useCallback(
+      id =>
+        setCard(prevCard => ({
+          ...prevCard,
+          isLiked: false,
+          likes: prevCard.likes - 1,
+        })),
+      [],
+    ),
+    useCallback(
+      id =>
+        setCard(prevCard => ({
+          ...prevCard,
+          isLiked: true,
+          likes: prevCard.likes + 1,
+        })),
+      [],
+    ),
   );
 
   const handleToggleLike = useCallback(
@@ -68,11 +67,11 @@ export const useCardsData = initialCardData => {
   );
 
   useEffect(() => {
-    setCards(initialCardData);
-  }, [initialCardData]);
+    setCard(cardData);
+  }, [cardData]);
 
   return {
-    cards,
+    card: { ...card, productImageSrcs },
     handleToggleLike,
   };
 };

--- a/src/hooks/useCardsData.js
+++ b/src/hooks/useCardsData.js
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useOptimisticUpdate } from './useOptimisticUpdate';
+import { createLike, deleteLike } from '../api/api';
+
+export const useCardsData = initialCardData => {
+  const [cards, setCards] = useState(initialCardData);
+
+  const { execute: addLike } = useOptimisticUpdate(
+    createLike,
+    useCallback(id => {
+      setCards(prevCards =>
+        prevCards.map(cardItem =>
+          cardItem.id === id
+            ? { ...cardItem, isLiked: true, likes: cardItem.likes + 1 }
+            : cardItem,
+        ),
+      );
+    }, []),
+
+    useCallback(id => {
+      setCards(prevCards =>
+        prevCards.map(cardItem =>
+          cardItem.id === id
+            ? { ...cardItem, isLiked: false, likes: cardItem.likes - 1 }
+            : cardItem,
+        ),
+      );
+    }, []),
+  );
+
+  const { execute: removeLike } = useOptimisticUpdate(
+    deleteLike,
+    useCallback(id => {
+      setCards(prevCards =>
+        prevCards.map(cardItem =>
+          cardItem.id === id
+            ? { ...cardItem, isLiked: false, likes: cardItem.likes - 1 }
+            : cardItem,
+        ),
+      );
+      console.log(cards);
+    }, []),
+    useCallback(id => {
+      setCards(prevCards =>
+        prevCards.map(cardItem =>
+          cardItem.id === id
+            ? { ...cardItem, isLiked: true, likes: cardItem.likes + 1 }
+            : cardItem,
+        ),
+      );
+    }, []),
+  );
+
+  const handleToggleLike = useCallback(
+    async (id, currentIsLiked) => {
+      try {
+        if (!currentIsLiked) {
+          await addLike(id);
+        } else {
+          await removeLike(id);
+        }
+      } catch (error) {
+        throw new Error(error);
+      }
+    },
+    [addLike, removeLike],
+  );
+
+  useEffect(() => {
+    setCards(initialCardData);
+  }, [initialCardData]);
+
+  return {
+    cards,
+    handleToggleLike,
+  };
+};

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+
+export const useInfiniteScroll = (
+  onIntersect,
+  hasMore,
+  isLoading,
+  intersectionOptions = {},
+) => {
+  const observerTargetRef = useRef(null); // 감지할 요소를 위한 ref
+  const {
+    root = null,
+    rootMargin = '0px',
+    threshold = 0.1,
+  } = intersectionOptions;
+
+  useEffect(() => {
+    const observerTarget = observerTargetRef.current;
+    if (!observerTarget) return;
+
+    const observer = new IntersectionObserver(
+      entries => {
+        if (entries[0].isIntersecting && hasMore && !isLoading) {
+          onIntersect();
+        }
+      },
+      { root, rootMargin, threshold },
+    );
+
+    observer.observe(observerTarget);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [
+    observerTargetRef,
+    onIntersect,
+    hasMore,
+    isLoading,
+    root,
+    rootMargin,
+    threshold,
+  ]);
+
+  return observerTargetRef;
+};

--- a/src/hooks/useLinkshopsData.js
+++ b/src/hooks/useLinkshopsData.js
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useAsync } from './useAsync';
+import { getLinkshops } from '../api/api';
+
+export const useLinkshopsData = () => {
+  const [linkshops, setLinkshops] = useState([]);
+  const [keyword, setKeyword] = useState('');
+  const [order, setOrder] = useState('recent');
+  const [cursor, setCursor] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+
+  const {
+    execute: loadLinkshops,
+    data: pageData = {},
+    isLoading,
+    error,
+  } = useAsync(getLinkshops, { delayLoadingTransition: true });
+
+  // 초기 데이터 및 검색과 정렬 변경 시 데이터 로드
+  useEffect(() => {
+    setLinkshops([]);
+    setCursor(0);
+    setHasMore(true);
+
+    const initialLoadOptions = {
+      keyword: keyword.trim(),
+      orderBy: order,
+      cursor: 0,
+    };
+    loadLinkshops(initialLoadOptions);
+  }, [loadLinkshops, keyword, order]);
+
+  // 로드된 데이터로 상태를 업데이트
+  useEffect(() => {
+    if (pageData && pageData.list) {
+      cursor
+        ? setLinkshops(prev => [...prev, ...pageData.list])
+        : setLinkshops(pageData.list);
+
+      setCursor(pageData.nextCursor);
+      setHasMore(pageData.nextCursor !== null);
+    }
+  }, [pageData]);
+
+  // 데이터를 더 불러오는 함수
+  const handleLoadMore = useCallback(() => {
+    if (!isLoading && hasMore) {
+      const nextLoadOptions = {
+        keyword: keyword.trim(),
+        orderBy: order,
+        cursor: cursor,
+      };
+      loadLinkshops(nextLoadOptions);
+    }
+  }, [keyword, order, cursor, isLoading, hasMore]);
+
+  return {
+    linkshops,
+    keyword,
+    setKeyword,
+    order,
+    setOrder,
+    cursor,
+    isLoading,
+    error,
+    hasMore,
+    handleLoadMore,
+  };
+};

--- a/src/hooks/useOptimisticUpdate.js
+++ b/src/hooks/useOptimisticUpdate.js
@@ -1,0 +1,30 @@
+import { useState, useCallback } from 'react';
+
+export const useOptimisticUpdate = (
+  asyncFunction,
+  onOptimisticUpdate,
+  onRollback,
+) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const execute = useCallback(
+    async (...args) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        onOptimisticUpdate(...args);
+        await asyncFunction(...args);
+      } catch (error) {
+        setError(error);
+        onRollback(...args);
+        throw error;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [asyncFunction, onOptimisticUpdate, onRollback],
+  );
+
+  return { isLoading, error, execute };
+};

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -91,6 +91,7 @@ const MainPage = () => {
       <LoadingIndicator
         $isLoading={isLoading}
         $hasMore={hasMore}
+        $isEmptyList={linkshops.length === 0}
         $isInitialLoad={cursor === 0}
       />
       {hasMore && <StObserveContainer ref={observerTargetRef} />}

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
 import CardList from '../components/CardList';
 import LoadingIndicator from '../components/LoadingIndicator';
 import { useAsync } from '../hooks/useAsync';
+import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
 import { getLinkshops } from './../api/api';
 import OrderSelector from './../components/OrderSelector';
 import SearchInput from './../components/SearchInput';
@@ -65,8 +66,6 @@ const MainPage = () => {
     error,
   } = useAsync(getLinkshops, { delayLoadingTransition: true });
 
-  const observerTargetRef = useRef();
-
   // 초기 데이터 및 검색과 정렬 변경 시 데이터 로드
   useEffect(() => {
     setLinkshops([]);
@@ -105,29 +104,12 @@ const MainPage = () => {
     }
   }, [keyword, order, cursor, isLoading, hasMore]);
 
-  // Intersection API를 활용한 무한 스크롤
-  useEffect(() => {
-    if (!observerTargetRef.current) return;
-
-    const observer = new IntersectionObserver(
-      entries => {
-        if (entries[0].isIntersecting && hasMore && !isLoading) {
-          handleLoadMore();
-        }
-      },
-      {
-        root: null,
-        rootMargin: '0px',
-        threshold: 0.1,
-      },
-    );
-
-    observer.observe(observerTargetRef.current);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [isLoading, hasMore, handleLoadMore]);
+  // Intersection을 활용한 무한 스크롤
+  const observerTargetRef = useInfiniteScroll(
+    handleLoadMore,
+    hasMore,
+    isLoading,
+  );
 
   const handleSearchChange = keyword => {
     setKeyword(keyword);

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,12 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
-
 import styled from 'styled-components';
 
 import CardList from '../components/CardList';
 import LoadingIndicator from '../components/LoadingIndicator';
-import { useAsync } from '../hooks/useAsync';
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll';
-import { getLinkshops } from './../api/api';
+import { useLinkshopsData } from '../hooks/useLinkshopsData';
 import OrderSelector from './../components/OrderSelector';
 import SearchInput from './../components/SearchInput';
 
@@ -53,56 +50,17 @@ const StObserveContainer = styled.div`
 `;
 
 const MainPage = () => {
-  const [linkshops, setLinkshops] = useState([]);
-  const [keyword, setKeyword] = useState('');
-  const [order, setOrder] = useState('recent');
-  const [cursor, setCursor] = useState(0);
-  const [hasMore, setHasMore] = useState(true);
-
   const {
-    execute: loadLinkshops,
-    data: pageData = {},
+    linkshops,
+    setKeyword,
+    order,
+    setOrder,
+    cursor,
     isLoading,
     error,
-  } = useAsync(getLinkshops, { delayLoadingTransition: true });
-
-  // 초기 데이터 및 검색과 정렬 변경 시 데이터 로드
-  useEffect(() => {
-    setLinkshops([]);
-    setCursor(0);
-    setHasMore(true);
-
-    const initialLoadOptions = {
-      keyword: keyword.trim(),
-      orderBy: order,
-      cursor: 0,
-    };
-    loadLinkshops(initialLoadOptions);
-  }, [loadLinkshops, keyword, order]);
-
-  // 로드된 데이터로 상태를 업데이트
-  useEffect(() => {
-    if (pageData && pageData.list) {
-      cursor
-        ? setLinkshops(prev => [...prev, ...pageData.list])
-        : setLinkshops(pageData.list);
-
-      setCursor(pageData.nextCursor);
-      setHasMore(pageData.nextCursor !== null);
-    }
-  }, [pageData]);
-
-  // 데이터를 더 불러오는 함수
-  const handleLoadMore = useCallback(() => {
-    if (!isLoading && hasMore) {
-      const nextLoadOptions = {
-        keyword: keyword.trim(),
-        orderBy: order,
-        cursor: cursor,
-      };
-      loadLinkshops(nextLoadOptions);
-    }
-  }, [keyword, order, cursor, isLoading, hasMore]);
+    hasMore,
+    handleLoadMore,
+  } = useLinkshopsData();
 
   // Intersection을 활용한 무한 스크롤
   const observerTargetRef = useInfiniteScroll(


### PR DESCRIPTION
1. 검색 결과가 없을 때, 더 불러올 데이터가 없다고 출력되는 문제를 수정했습니다.
2. 개별 카드 클릭 시, 상세 페이지로 이동하는 부분이 누락되었던 점을 수정했습니다.
3. 좋아요를 핸들하는 CardList의 로직을 Card로 옮겨 좋아요를 누른 카드 대상을 찾기 위해 find와 같은 함수를 사용해 불필요한 순회를 방지하도록 수정했습니다.
4. 메인 페이지의 전체적인 데이터패칭 및 좋아요와 관련된 데이터 패칭 로직을 커스텀 훅으로 관리하여 관심사의 분리 및 비동기 패칭과 낙관적 업데이트에 대한 재사용성을 개선했습니다.
5. LoadingIndicator 출력 부분을 개선해 메인 페이지 로드시 발생하는 CLS를 개선했습니다.