### PR TITLE
Feature/BPT5-52-card carousel slide 수정 및 커스텀훅분리, 스켈레톤스타일 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.9.0",
+        "lodash": "^4.17.21",
         "lodash.throttle": "^4.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -3793,6 +3794,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "axios": "^1.9.0",
+    "lodash": "^4.17.21",
     "lodash.throttle": "^4.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/components/CardList.jsx
+++ b/src/components/CardList.jsx
@@ -34,6 +34,7 @@ const StyledLink = styled(Link)`
     width: calc((100% - 24px) / 2);
     max-width: 589px;
   }
+  -webkit-tap-highlight-color: transparent;
 `;
 
 function CardList({ cardData, $isLoading }) {
@@ -44,7 +45,11 @@ function CardList({ cardData, $isLoading }) {
   return (
     <CardListWrapper>
       {cardData.map(cardItem => (
-        <StyledLink key={cardItem.id} to={`/link/${cardItem.userId}`}>
+        <StyledLink
+          key={cardItem.id}
+          to={`/link/${cardItem.userId}`}
+          draggable='false'
+        >
           <Card cardData={cardItem} />
         </StyledLink>
       ))}

--- a/src/components/Likes.jsx
+++ b/src/components/Likes.jsx
@@ -57,6 +57,7 @@ const Likes = ({
       <StHeartImg
         src={src}
         alt={'좋아요 이미지 버튼'}
+        width={DEFAULT_HEART_SIZE}
         loading='lazy'
         $isBouncing={isBouncing}
       />

--- a/src/components/Likes.jsx
+++ b/src/components/Likes.jsx
@@ -1,23 +1,35 @@
-import styled from 'styled-components';
+import { useState } from 'react';
 
-import emptyHeartImg from '../assets/icon/btn_empty_heart.png'; // svg가 나을까 싶습니다.
-import filledHeartImg from '../assets/icon/btn_fill_heart.png'; // svg가 나을까 싶습니다.
+import styled, { keyframes } from 'styled-components';
+
+import emptyHeartImg from '../assets/icon/btn_empty_heart.png';
+import filledHeartImg from '../assets/icon/btn_fill_heart.png';
 import { FontTypes } from '../styles/theme';
 import { applyFontStyles } from './../styles/mixins';
 
 const DEFAULT_HEART_SIZE = '24px';
 
+// 클릭시 통통튀는 키프레임
+const bounce = keyframes`
+  0% { transform: scale(1); }
+  30% { transform: scale(1.3); }
+  60% { transform: scale(0.9); }
+  100% { transform: scale(1); }
+`;
+
 const StLikesWrapper = styled.div`
   display: inline-flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.3125rem; // 5px
+  gap: 0.3125rem;
   cursor: pointer;
 `;
 
 const StHeartImg = styled.img`
   aspect-ratio: 1/1;
+  animation: ${({ $isBouncing }) => ($isBouncing ? bounce : 'none')} 0.4s ease;
 `;
+
 const StLikesCount = styled.p`
   ${applyFontStyles(FontTypes.BOLD16)}
 `;
@@ -29,10 +41,14 @@ const Likes = ({
   onToggleLike: handleToggleLike,
   likes,
 }) => {
+  const [isBouncing, setIsBouncing] = useState(false); // 통통튀는 하트 애니메이션 state
   const src = isLiked ? filledHeartImg : emptyHeartImg;
 
   const handleToggleLikeClick = e => {
     e.preventDefault();
+    setIsBouncing(true);
+    setTimeout(() => setIsBouncing(false), 400); // 애니메이션 끝나면 초기화
+
     handleToggleLike(id, isLiked);
   };
 
@@ -41,8 +57,8 @@ const Likes = ({
       <StHeartImg
         src={src}
         alt={'좋아요 이미지 버튼'}
-        width={DEFAULT_HEART_SIZE}
         loading='lazy'
+        $isBouncing={isBouncing}
       />
       <StLikesCount>{likes}</StLikesCount>
     </StLikesWrapper>

--- a/src/components/LinkshopProductImage.jsx
+++ b/src/components/LinkshopProductImage.jsx
@@ -5,9 +5,9 @@ import styled, { keyframes } from 'styled-components';
 const DEFAULT_PRODUCT_IMG = 'https://placehold.co/95x95';
 
 const skeletonPulse = keyframes`
-  0% { background-color: #eee; }
-  50% { background-color: #ddd; }
-  100% { background-color: #eee; }
+  0% { filter: brightness(1); }
+  50% { filter: brightness(0.9); }
+  100% { filter: brightness(1); }
 `;
 
 const ProductImgWrapper = styled.div`
@@ -37,10 +37,13 @@ const SkeletonOverlay = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
+  background-color: #eee;
   animation: ${skeletonPulse} 1.5s infinite ease-in-out;
   border-radius: 15px;
   z-index: 1;
-  display: ${({ $isLoading }) => ($isLoading ? 'block' : 'none')};
+  opacity: ${({ $isLoading }) => ($isLoading ? 1 : 0)};
+  transition: opacity 0.4s ease;
+  pointer-events: none;
 `;
 
 function LinkshopProductImage({ src, alt }) {

--- a/src/components/LinkshopProductImage.jsx
+++ b/src/components/LinkshopProductImage.jsx
@@ -1,45 +1,75 @@
-// components/LinkshopProductImage.jsx
-import { useEffect, useState } from 'react'; // useState 훅 import
+import { useEffect, useState } from 'react';
 
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 const DEFAULT_PRODUCT_IMG = 'https://placehold.co/95x95';
+
+const skeletonPulse = keyframes`
+  0% { background-color: #eee; }
+  50% { background-color: #ddd; }
+  100% { background-color: #eee; }
+`;
+
 const ProductImgWrapper = styled.div`
   width: 95px;
   height: 95px;
-  overflow: hidden;
   border-radius: 15px;
+  overflow: hidden;
+  position: relative;
 `;
+
 const ProductImage = styled.img`
   width: 100%;
   height: 100%;
-
   object-fit: cover;
   object-position: center;
   aspect-ratio: 1/1;
+  transition:
+    filter 0.4s ease,
+    opacity 0.4s ease;
+  filter: ${({ $isLoading }) => ($isLoading ? 'blur(10px)' : 'none')};
+  opacity: ${({ $isLoading }) => ($isLoading ? 0.6 : 1)};
+`;
+
+const SkeletonOverlay = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  animation: ${skeletonPulse} 1.5s infinite ease-in-out;
+  border-radius: 15px;
+  z-index: 1;
+  display: ${({ $isLoading }) => ($isLoading ? 'block' : 'none')};
 `;
 
 function LinkshopProductImage({ src, alt }) {
-  const [currentSrc, setCurrentSrc] = useState(src); // 이미지 URL을 관리할 상태
+  const [currentSrc, setCurrentSrc] = useState(src);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     setCurrentSrc(src);
+    setIsLoading(true); // 새 src가 들어오면 로딩 다시 시작
   }, [src]);
 
   const handleImageError = () => {
-    // 현재 이미지가 이미 기본 이미지라면 더 이상 변경하지 않음
     if (currentSrc !== DEFAULT_PRODUCT_IMG) {
-      setCurrentSrc(DEFAULT_PRODUCT_IMG); // 기본 이미지로 교체
+      setCurrentSrc(DEFAULT_PRODUCT_IMG);
     }
   };
 
   return (
     <ProductImgWrapper>
+      <SkeletonOverlay $isLoading={isLoading} />
       <ProductImage
-        src={currentSrc || DEFAULT_PRODUCT_IMG} // currentSrc가 없거나 null이면 기본 이미지 사용
+        src={currentSrc || DEFAULT_PRODUCT_IMG}
         alt={alt}
+        width='95'
+        height='95'
         loading='lazy'
-        onError={handleImageError} // 이미지 로드 실패 시 handleImageError 함수 호출
+        onLoad={() => setIsLoading(false)}
+        onError={handleImageError}
+        $isLoading={isLoading}
       />
     </ProductImgWrapper>
   );

--- a/src/hooks/useIsLargeScreen.js
+++ b/src/hooks/useIsLargeScreen.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export function useIsLargeScreen(breakpoint = 768) {
+  const [isLargeScreen, setIsLargeScreen] = useState(
+    typeof window !== 'undefined' ? window.innerWidth >= breakpoint : false,
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsLargeScreen(window.innerWidth >= breakpoint);
+    };
+
+    handleResize(); // mount 시 초기화
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [breakpoint]);
+
+  return isLargeScreen;
+}


### PR DESCRIPTION
늦어서 죄송합니다ㅠㅠ

수정내역 
- 모바일과 태블릿부분에서 등장하는 카드내부의 버튼을 수정했습니다. 첫번째 슬라이드일때는 prev버튼이 보이지않고 마지막 슬라이드일때는 next버튼이 보이지 않게 했습니다. 추가적으로 상세페이지로 이동해야하기때문에 a태그가 사용됐는데 이때 슬라이드 드래그시 주소가 딸려오는 부분도 수정했습니다. 맥os환경일때 a태그에 걸려있는 기본 active도 css한줄로 처리했습니다. (파란색 배경색이 씌워졌었음)
- 카드컴포넌트에서는 화면사이즈를 감지해서 슬라이드 오토플레이 부분을 조작하는 함수를 커스텀훅으로 분리했습니다. 캐러셀부분을 커스텀훅으로 분리하는 방법도 추천해주셨는데 이부분은 동희님이 동희님의 코드를 커스텀훅으로 빼는 작업을 아직 pr하지 않았다고해서 pr완료 되면 확인하고 분리해보겠습니다.
- 링크샵프로덕트이미지 컴포넌트에 스켈레톤 스타일을 구현해보았습니다. .WebP로 변환하여 최적화하는 방법은 백엔드의 도움이 필요하다고 하여 적용하지않았습니다 .

감사합니다 ! 

++ 좋아요 버튼 클릭시 통통튀는 애니메이션을 추가해봤습니다 ...