### PR TITLE
feat:BPT5-60:이미지 업로드 구조 개선, 생성 버튼 로딩,에러 처리

### DIFF
--- a/src/components/CreateFileField.jsx
+++ b/src/components/CreateFileField.jsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { FieldContainer, NoneValidMessage } from './CreateField';
-import { uploadImage } from '../api/api';
 import closeBtn from '../assets/icon/btn_close.png';
 import defaultProductImg from '../assets/img/img_product.png';
 import defaultShopImg from '../assets/img/img_profile.png';
@@ -26,6 +25,7 @@ const AddFileButton = styled.label`
   font-weight: 500;
   color: ${theme.colors.pri};
   white-space: nowrap;
+  cursor: pointer;
 `;
 
 const STFileInput = styled.input`
@@ -73,7 +73,7 @@ export const ButtonX = styled.img`
   height: 70%;
 `;
 
-const NONE_VALID_MESSAGE = '이미지를 업로드해 주세요.';
+const NONE_VALID_MESSAGE = '이미지를 업로드해 주세요';
 
 const FileField = ({
   placeholder,
@@ -83,41 +83,51 @@ const FileField = ({
   onSaveProductInfo,
   setIsDisabled,
 }) => {
-  const [selectedFileUrl, setSelectedFileUrl] = useState(async () => {
-    const defaultImg =
-      label === '프로필 이미지' ? defaultShopImg : defaultProductImg;
-    const res = await fetch(defaultImg);
-    const blob = await res.blob();
-    const file = new File([blob], 'default-image.png', { type: blob.type });
-    const url = await uploadImage(file);
-    setSelectedFileUrl(prev => url);
-    onCheckValidForm(prev => true);
-  });
+  const [selectedFileUrl, setSelectedFileUrl] = useState(null);
+
   const [previewImage, setPreviewImage] = useState(() => {
     return label === '프로필 이미지' ? defaultShopImg : defaultProductImg;
   });
   const [isFileSelected, setIsFileSelected] = useState(true);
 
-  const handleChangeImage = async e => {
+  const loadDefaultFile = async () => {
+    const defaultImg =
+      label === '프로필 이미지' ? defaultShopImg : defaultProductImg;
+    const res = await fetch(defaultImg);
+    const blob = await res.blob();
+    const file = new File([blob], 'default-image.png', { type: blob.type });
+    setSelectedFileUrl(prev => file);
+    onCheckValidForm(prev => true);
+  };
+
+  const handleChangeImage = e => {
     const file = e.target.files[0];
+
+    e.target.value = null;
+
     //유효성 검사
-    if (!validateImage(file)) {
-      alert('jpg, jpeg, png, webp, avif형식의 이미지만 업로드할 수 있습니다.');
+    const { hasError, message } = validateImage(file);
+    if (hasError) {
+      alert(message);
       return;
     }
     const renamedFile = renameFile(file);
 
-    const url = await uploadImage(renamedFile);
     const preview = URL.createObjectURL(renamedFile);
     setPreviewImage(prev => preview);
-    setSelectedFileUrl(prev => url);
+    setSelectedFileUrl(prev => renamedFile);
     setIsFileSelected(prev => true);
     onCheckValidForm(prev => true);
     setIsDisabled(prev => false);
   };
 
   const handleDeleteImage = () => {
-    setPreviewImage(prev => null);
+    setPreviewImage(prev => {
+      if (prev) {
+        URL.revokeObjectURL(prev);
+      }
+      return null;
+    });
     setSelectedFileUrl(prev => null);
     setIsFileSelected(prev => false);
     onCheckValidForm(prev => false);
@@ -142,13 +152,17 @@ const FileField = ({
     });
   }, [selectedFileUrl]);
 
+  useEffect(() => {
+    loadDefaultFile();
+  }, []);
+
   return (
     <FieldContainer>
       <AddFileButton htmlFor={inputId}>파일 첨부</AddFileButton>
       <STFileInput
         id={inputId}
         type='file'
-        accept='image/png image/jpeg' //여기
+        accept='image/png image/jpeg image/webp image/avif' //여기
         onChange={handleChangeImage}
       />
       <STTitle>{label}</STTitle>

--- a/src/pages/CreateShopPage.jsx
+++ b/src/pages/CreateShopPage.jsx
@@ -3,11 +3,12 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { createLinkshop } from '../api/api';
+import { createLinkshop, uploadImage } from '../api/api';
 import ConfirmCreateModal from '../components/ConfirmCreateModal';
 import CreateProducts from '../components/CreateProducts';
 import CreateShop from '../components/CreateShop';
 import BaseButton from '../components/PrimaryButton';
+import { useAsync } from '../hooks/useAsync';
 import theme from '../styles/theme';
 import { ColorTypes } from '../styles/theme';
 import deepIsEmpty from '../utils/deepIsEmpty';
@@ -49,8 +50,18 @@ function CreateShopPage({ onSuccess }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
   const [disabled, setDisabled] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   //isDisabled => ui에 영향을 주지 않고 필드의 데이터값이 유효한지 확인하는 용도
   //disabled => 실제 버튼이 활성화ui에 영향을 주는 상태, isDisabled와 completeData를 교차검증하여 최종적으로 상태가 변경
+  const { execute: asyncUploadImage, error: imageError } = useAsync(
+    uploadImage,
+    { delayLoadingTransition: true },
+  );
+  const {
+    execute: asyncCreateLinkshop,
+    isLoading: createLoading,
+    error: createError,
+  } = useAsync(createLinkshop, { delayLoadingTransition: true });
   const navigate = useNavigate();
 
   const handleConfirm = () => {
@@ -59,27 +70,36 @@ function CreateShopPage({ onSuccess }) {
     navigate('/list');
   };
 
+  const onSuccsessCreate = () => {
+    if (!createError) {
+      setIsModalOpen(true);
+    }
+  };
+
   const handleCreate = async () => {
-    // 1. 데이터 저장 로직 수행 (예: API 호출)
+    // 이미지 업로드 -> 데이터 전송 두 종류 api 순차 실행
+    setIsLoading(prev => true);
     const copiedList = completeData.products.map(product => {
       return { ...product };
     });
     for (const product of copiedList) {
+      product.imageUrl = await asyncUploadImage(product.imageUrl);
       delete product.id;
     }
+
+    const copiedShop = { ...completeData.shop };
+    copiedShop.imageUrl = await asyncUploadImage(copiedShop.imageUrl);
+    console.log(copiedList);
+    console.log(copiedShop);
 
     const dataForSubmit = {
       ...completeData,
       products: [...copiedList],
+      shop: { ...copiedShop },
     };
 
-    const { error } = await createLinkshop(dataForSubmit);
-    if (error) {
-      alert(error.message);
-      return;
-    }
-
-    setIsModalOpen(true);
+    const res = await asyncCreateLinkshop(dataForSubmit);
+    onSuccsessCreate();
   };
 
   //폼 하나의 검사가 통과하고, 나머지에 빈값이 없지만 오류값은 있는 경우 -> 해결하려면 모든 필드에서도 버튼 컨트롤을 해야함
@@ -92,7 +112,19 @@ function CreateShopPage({ onSuccess }) {
     } else if (!isDisabled && !deepIsEmpty(completeData)) {
       setDisabled(prev => false);
     }
-  }, [isDisabled]);
+  }, [isDisabled, completeData]);
+
+  useEffect(() => {
+    const current = createLoading;
+    setIsLoading(prev => (prev !== current ? createLoading : prev));
+  }, [createLoading]);
+
+  useEffect(() => {
+    if (imageError || createError) {
+      alert('다시시도해주세요');
+      setIsLoading(prev => false);
+    }
+  }, [imageError, createError]);
 
   return (
     <PageContainer>
@@ -104,8 +136,12 @@ function CreateShopPage({ onSuccess }) {
         setIsDisabled={setIsDisabled}
         onSaveCompleteData={setCompleteData}
       />
-      <CreateButton type='button' onClick={handleCreate} disabled={disabled}>
-        생성하기
+      <CreateButton
+        type='button'
+        onClick={handleCreate}
+        disabled={disabled || isLoading}
+      >
+        {isLoading ? '생성중입니다..' : '생성하기'}
       </CreateButton>
       <ConfirmCreateModal
         onConfirm={handleConfirm}

--- a/src/utils/deepIsEmpty.js
+++ b/src/utils/deepIsEmpty.js
@@ -5,6 +5,7 @@ function deepIsEmpty(obj) {
 
   if (typeof obj === 'object' && obj !== null) {
     for (const key in obj) {
+      if (key === 'webkitRelativePath') continue;
       if (deepIsEmpty(obj[key])) return true;
     }
   }

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -36,5 +36,8 @@ export const validateImage = file => {
   const isExtValid = validExtensions.includes(extension);
   const isMimeValid = validMimeTypes.includes(file.type);
 
-  return isExtValid && isMimeValid && file.type.startsWith('image/');
+  return {
+    hasError: !(isExtValid && isMimeValid && file.type.startsWith('image/')),
+    message: 'jpg, jpeg, png, webp, avif 형식의 이미지만 업로드할 수 있습니다.',
+  };
 };


### PR DESCRIPTION
기존의 파일 첨부를 할 때 이미지 업로드 요청을 보내던 방식을, 전체 데이터 post 요청을 보내기 직전에 이미지 업로드 요청을 동시에 수행하도록 구조를 개선해서, 로딩 처리를 한 번에 할 수 있도록 했습니다.